### PR TITLE
Make agent wait for workspace pull before processing first message

### DIFF
--- a/app/backend/services/claudeBackupService.ts
+++ b/app/backend/services/claudeBackupService.ts
@@ -32,7 +32,7 @@ export async function pullClaudeConfig(
     `[Backup Pull] Enqueueing claude config pull from ${workspaceClaudeConfigPath} to ${localClaudeConfigPath}...`
   );
 
-  const { taskId } = enqueuePull({
+  const taskId = enqueuePull({
     userId,
     workspacePath: workspaceClaudeConfigPath,
     localPath: localClaudeConfigPath,
@@ -89,7 +89,7 @@ export async function manualPullClaudeConfig(
     `[Manual Pull] Enqueueing claude config pull from ${workspaceClaudeConfigPath} to ${localClaudeConfigPath}...`
   );
 
-  const { taskId } = enqueuePull({
+  const taskId = enqueuePull({
     userId,
     workspacePath: workspaceClaudeConfigPath,
     localPath: localClaudeConfigPath,

--- a/app/backend/services/workspaceQueueService.ts
+++ b/app/backend/services/workspaceQueueService.ts
@@ -58,10 +58,6 @@ const DEFAULT_CONFIG: QueueConfig = {
 // In-memory state
 const userTaskCounts = new Map<string, number>();
 const pendingTasks = new Map<string, WorkspaceSyncTask>();
-const taskCompletionCallbacks = new Map<
-  string,
-  { resolve: () => void; reject: (error: Error) => void }
->();
 
 // Queue instance (singleton)
 let queue: queueAsPromised<WorkspaceSyncTask> | null = null;
@@ -119,11 +115,9 @@ async function processTask(task: WorkspaceSyncTask): Promise<void> {
         break;
     }
 
-    // Success: cleanup and resolve completion callback
+    // Success: cleanup
     pendingTasks.delete(task.id);
     decrementUserCount(task.userId);
-    taskCompletionCallbacks.get(task.id)?.resolve();
-    taskCompletionCallbacks.delete(task.id);
     console.log(
       `[WorkspaceQueue] Task ${task.id} (${task.type}) completed successfully`
     );
@@ -149,17 +143,9 @@ async function processTask(task: WorkspaceSyncTask): Promise<void> {
         });
       }, delay);
     } else {
-      // Final failure: cleanup and reject completion callback
+      // Final failure: cleanup
       pendingTasks.delete(task.id);
       decrementUserCount(task.userId);
-      taskCompletionCallbacks
-        .get(task.id)
-        ?.reject(
-          new Error(
-            `Task ${task.id} failed after ${config.maxRetries} retries: ${error.message}`
-          )
-        );
-      taskCompletionCallbacks.delete(task.id);
       console.error(
         `[WorkspaceQueue] Task ${task.id} (${task.type}) failed after ${config.maxRetries} retries`
       );
@@ -199,12 +185,6 @@ export function initQueue(customConfig?: Partial<QueueConfig>): void {
   );
 }
 
-// Enqueue pull task result type
-export interface EnqueuePullResult {
-  taskId: string;
-  completed: Promise<void>;
-}
-
 // Enqueue pull task
 export function enqueuePull(params: {
   userId: string;
@@ -212,7 +192,7 @@ export function enqueuePull(params: {
   localPath: string;
   overwrite?: boolean;
   token?: string;
-}): EnqueuePullResult {
+}): string {
   ensureQueueInitialized();
   const task: PullTask = {
     id: crypto.randomUUID(),
@@ -225,14 +205,8 @@ export function enqueuePull(params: {
     createdAt: Date.now(),
     retryCount: 0,
   };
-
-  // Create completion promise
-  const completed = new Promise<void>((resolve, reject) => {
-    taskCompletionCallbacks.set(task.id, { resolve, reject });
-  });
-
   enqueueTask(task);
-  return { taskId: task.id, completed };
+  return task.id;
 }
 
 // Enqueue push task


### PR DESCRIPTION
- Add completion Promise tracking to enqueuePull in workspaceQueueService
- Modify MessageStream to accept waitForReady Promise and await it before yielding first message
- Pass pull completion Promise from handlers to agent
- Update CLAUDE.md to reflect new architecture

This allows API to return session_id immediately while agent waits for
workspace sync to complete before processing user input.